### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that provides tools for interacting with the GitHub API through PyGithub. This server enables AI assistants to perform GitHub operations like managing issues, repositories, and pull requests.
 
+<a href="https://glama.ai/mcp/servers/orj9keaji9">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/orj9keaji9/badge" alt="PyGithub Server MCP server" />
+</a>
+
 ## Features
 
 - Modular Tool Architecture:


### PR DESCRIPTION
This PR adds a badge for the [PyGithub MCP Server](https://glama.ai/mcp/servers/orj9keaji9) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/orj9keaji9">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/orj9keaji9/badge" alt="PyGithub Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.